### PR TITLE
Fix negative prompt handling

### DIFF
--- a/scripts/unprompted.py
+++ b/scripts/unprompted.py
@@ -44,6 +44,7 @@ class Scripts(scripts.Script):
 
 		# Reset vars
 		original_prompt = p.prompt;
+		original_negative_prompt = p.negative_prompt;
 		Unprompted.shortcode_user_vars = {}
 
 		# Extra vars
@@ -55,6 +56,7 @@ class Scripts(scripts.Script):
 				Unprompted.shortcode_user_vars[att] = getattr(p,att)
 
 		Unprompted.shortcode_user_vars["prompt"] = Unprompted.process_string(original_prompt)
+		Unprompted.shortcode_user_vars["negative_prompt"] = Unprompted.process_string(original_negative_prompt)
 
 		# Apply any updates to system vars
 		for att in dir(p):
@@ -71,19 +73,21 @@ class Scripts(scripts.Script):
 		# Batch support
 		if (Unprompted.Config.stable_diffusion.batch_support):
 			for i, val in enumerate(p.all_prompts):
+				print(i, p.all_negative_prompts[i])
 				Unprompted.shortcode_user_vars["batch_index"] = i
 
-				if (i == 0): p.all_prompts[i] = Unprompted.shortcode_user_vars["prompt"]
+				if (i == 0): 
+					p.all_prompts[i] = Unprompted.shortcode_user_vars["prompt"]
+					p.all_negative_prompts[i] = Unprompted.shortcode_user_vars["negative_prompt"]
 				else:
-					p.all_prompts[i] = Unprompted.process_string(original_prompt)			
-				Unprompted.log(f"Result {i}: {p.all_prompts[i]}",False,"INFO")
+					p.all_prompts[i] = Unprompted.process_string(original_prompt)
+					p.all_negative_prompts[i] = Unprompted.process_string(original_negative_prompt)
+				Unprompted.log(f"Result {i}: {p.all_prompts[i]}",False)
 		# Keep the same prompt between runs
 		else:
 			for i, val in enumerate(p.all_prompts):
 				p.all_prompts[i] = Unprompted.shortcode_user_vars["prompt"]
-
-		# Process any remaining shortcodes in the negative prompt
-		p.negative_prompt = Unprompted.process_string(p.negative_prompt)
+				p.all_negative_prompts[i] = Unprompted.shortcode_user_vars["negative_prompt"]
 
 		# Skips the bulk of inference (note: still produces a blank image)
 		if (dry_run):


### PR DESCRIPTION
The negative prompt was not applied after processing. This way it's handled the same way positive prompt is.
I hope it's okay this way, I assume `all_negative_prompts` is always the same length as `all_prompts`.

Fixes #20 hopefully