### PR TITLE
Txt2mask padding dilate

### DIFF
--- a/shortcodes/stable_diffusion/txt2mask.py
+++ b/shortcodes/stable_diffusion/txt2mask.py
@@ -101,7 +101,7 @@ class Shortcode():
 				transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
 				transforms.Resize((512, 512)),
 			])
-			flattened_input = flattened(self.Unprompted.shortcode_user_vars["init_images"][0], opts.img2img_background_color)
+			flattened_input = flatten(self.Unprompted.shortcode_user_vars["init_images"][0], opts.img2img_background_color)
 			img = transform(flattened_input).unsqueeze(0)
 
 			# predict

--- a/shortcodes/stable_diffusion/txt2mask.py
+++ b/shortcodes/stable_diffusion/txt2mask.py
@@ -70,8 +70,8 @@ class Shortcode():
 				# TODO: Figure out how to convert the plot above to numpy instead of re-loading image
 				img = cv2.imread(filename)
 
-				if smoothing_kernel is not None: img = cv2.filter2D(img,-1,smoothing_kernel)
 				if padding_dilation_kernel is not None: img = cv2.dilate(img,padding_dilation_kernel,iterations=1)
+				if smoothing_kernel is not None: img = cv2.filter2D(img,-1,smoothing_kernel)
 
 				gray_image = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
 				(thresh, bw_image) = cv2.threshold(gray_image, mask_precision, 255, cv2.THRESH_BINARY)

--- a/shortcodes/stable_diffusion/txt2mask.py
+++ b/shortcodes/stable_diffusion/txt2mask.py
@@ -14,6 +14,8 @@ class Shortcode():
 		from matplotlib import pyplot as plt
 		import cv2
 		import numpy
+		from modules.images import flatten
+		from modules.shared import opts
 
 		brush_mask_mode = self.Unprompted.parse_advanced(kwargs["mode"],context) if "mode" in kwargs else "add"
 		self.show = True if "show" in pargs else False
@@ -99,7 +101,8 @@ class Shortcode():
 				transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
 				transforms.Resize((512, 512)),
 			])
-			img = transform(self.Unprompted.shortcode_user_vars["init_images"][0]).unsqueeze(0)
+			flattened_input = flattened(self.Unprompted.shortcode_user_vars["init_images"][0], opts.img2img_background_color)
+			img = transform(flattened_input).unsqueeze(0)
 
 			# predict
 			with torch.no_grad():


### PR DESCRIPTION
(This is on top of my previous pr that fixes the rgba txt2mask error, otherwise I can't run anything)

I tried for a bit to fix the padding in txt2mask, but conceptually I don't think that the way that it was working (a resize and a crop) is actually how you need it to work to properly pad the mask. Since we have opencv anyway, this pr changes it to a dilate on the mask, which is closer to padding pixels around the alpha areas.

It isn't perfect, since a dilate loses a lot of the definition of the mask. Probably what we actually want is to threshold a distance map which I believe will give us a better result, but it's at the very least more than I want to get into tonight.