### PR TITLE
Add template editor tab to the UI. 

### DIFF
--- a/javascript/umprompted_template_editor.js
+++ b/javascript/umprompted_template_editor.js
@@ -1,0 +1,47 @@
+function loadFile(file_name) {
+    // print the filename to the console
+    console.log(file_name);
+    var textarea =  gradioApp().querySelector("#save_name > label > textarea")
+    textarea.value = file_name;
+    console.log(textarea)
+
+    updateInput(textarea)
+    // wait 200 ms for the event to process then click the load button
+    setTimeout(clickLoad, 200);
+}
+
+function clickLoad() {
+    var loadFileButton = document.getElementById("load_button_unprompted");
+    loadFileButton.click();
+
+}
+function registerPrompt(tabname, id){
+    var textarea = gradioApp().querySelector("#" + id + " > label > textarea");
+
+    if (! activePromptTextarea[tabname]){
+        activePromptTextarea[tabname] = textarea
+    }
+
+    textarea.addEventListener("focus", function(){
+        activePromptTextarea[tabname] = textarea;
+    });
+}
+
+function unpromptedStartup() {
+    console.log("We are in unprompted startup");
+    var refreshButton = document.getElementById("refresh_button_unprompted");
+    refreshButton.click();
+    setupExtraNetworksForTab('unprompted_edit_space')
+    registerPrompt('unprompted_edit_space', 'unprompted_edit_space_prompt')
+}
+
+addEventListener('click', (event) => {
+
+    let target = event.originalTarget || event.composedPath()[0];
+    // check if the thing we clicked on it s button with the word unprompted in the content
+    if (! target.matches("button")) return;
+    if (! target.textContent.includes("Unprompted")) return;
+    if (! target.textContent.includes("Editor")) return;
+	loaded_unprompted_template_edit=true;
+    unpromptedStartup(event);
+});

--- a/scripts/unprompted_template_editer.py
+++ b/scripts/unprompted_template_editer.py
@@ -1,0 +1,115 @@
+import os.path
+from pathlib import Path
+
+import pathlib
+import os
+import re
+import glob
+from modules import extra_networks
+from modules.ui_components import FormRow, FormColumn, FormGroup, ToolButton, FormHTML
+
+import modules.scripts as scripts
+import gradio as gr
+from modules.ui_components import ToolButton
+
+from modules.processing import Processed, process_images
+from modules.shared import opts
+from modules import script_callbacks, sd_models, shared
+
+refresh_symbol = '\U0001f504'  # 🔄
+folder_symbol = '\U0001f4c2'  # 📂
+save_style_symbol = '\U0001f4be'  # 💾
+extra_networks_symbol = '\U0001F3B4'  # 🎴
+
+from lib_unprompted.shared import Unprompted
+base_dir = scripts.basedir()
+Unprompted = Unprompted(base_dir)
+folder = f"{base_dir}/{Unprompted.Config.template_directory}"
+
+def get_file_list(folder):
+    return [f for f in os.listdir(folder) if f.endswith('.txt')]
+
+def generate_file_list_html(file_list):
+    html_content = "<div style='height: 300px; overflow-y: scroll;'><ul>"
+    for file in file_list:
+        # print(f"file: {file}")
+        html_content += f"<li><a href='#' class='file-link' onclick='loadFile(\"{file}\")'>{file}</a></li>"
+    html_content += "</ul></div>"
+    return html_content
+
+
+
+def on_ui_tabs():
+    def refresh_file_list():
+        # print(f"REFRESHING LIST: {folder}")
+        file_list = get_file_list(f"{folder}")
+        file_list_html = generate_file_list_html(file_list)
+        html_update = None
+        html_update = gr.HTML.update(file_list_html)
+        return html_update
+
+    def load_file(file_name):
+        # print(f"loading: {file_name}")
+
+        with open(f"{folder}/{file_name}", "r") as file:
+            content = file.read()
+        # print(f"content: {content}")
+        # update main_edit_space woth content
+        return content
+
+    def save_file(file_name, content):
+        # print(f"loading: {file_name}")
+        with open(f"{folder}/{file_name}", "w") as file:
+            file.write(content)
+
+    with gr.Blocks() as unprompted_editor_ui:
+        with gr.Row(elem_id=f"unprompted_toprow"):
+            with gr.Column(scale=1, min_width=200):
+                # Add HTML element for file list
+                templates = gr.HTML(value="", elem_id="file_list", css=".file_list_container { height: 300px; overflow-y: scroll; }")
+                with gr.Row():  
+                    refresh_button = ToolButton(value=refresh_symbol, elem_id=f"refresh_button_unprompted")
+                    load_button = ToolButton(value=folder_symbol, elem_id=f"load_button_unprompted")
+                    save_button = ToolButton(value=save_style_symbol, elem_id=f"save_button_unprompted")
+                with gr.Row():
+                    # Add save name text box
+                    save_name = gr.Textbox(value="", label="Save Name", elem_id="save_name")
+            with gr.Column(scale=4, min_width=900):
+                
+                main_edit_space = gr.Textbox(value="", label="Main Editor", interactive=True, lines=20, elem_id="unprompted_edit_space_prompt")
+                extra_networks_button = ToolButton(value=extra_networks_symbol, elem_id=f"unprompted_edit_space_extra_networks_button")
+                with FormRow( elem_id="unprompted_edit_space_extra_networks", visible=False) as extra_networks:
+                    from modules import ui_extra_networks
+                    extra_networks_ui_unprompted_edit_space = ui_extra_networks.create_ui(extra_networks, extra_networks_button, 'unprompted_edit_space')
+                    extra_networks_ui_unprompted_gallery = gr.Textbox(visible=False)
+        ui_extra_networks.setup_ui(extra_networks_ui_unprompted_edit_space, extra_networks_ui_unprompted_gallery)
+        refresh_button.click(
+            fn=refresh_file_list,
+            inputs=[
+            ],
+            outputs=[
+            templates,
+            ]
+        )
+        load_button.click(
+            fn=load_file,
+            inputs=[
+                save_name,
+            ],
+            outputs=[
+                main_edit_space,
+            ]
+        )
+        save_button.click(
+            fn=save_file,
+            inputs=[
+                save_name,
+                main_edit_space,
+            ],
+            outputs=[
+            ]
+        )
+
+    return (unprompted_editor_ui, "Unprompted Template Editer", "unprompted_editor_ui"),
+
+script_callbacks.on_ui_tabs(on_ui_tabs)

--- a/scripts/unprompted_template_editer.py
+++ b/scripts/unprompted_template_editer.py
@@ -17,8 +17,8 @@ from modules.shared import opts
 from modules import script_callbacks, sd_models, shared
 
 refresh_symbol = '\U0001f504'  # 🔄
-folder_symbol = '\U0001f4c2'  # 📂
-save_style_symbol = '\U0001f4be'  # 💾
+folder_symbol_unprompted = '\U0001f5c1'  # 🗁
+save_style_symbol_unprompted = '\U0001f5ab'  # 🖫
 extra_networks_symbol = '\U0001F3B4'  # 🎴
 
 from lib_unprompted.shared import Unprompted
@@ -33,7 +33,7 @@ def generate_file_list_html(file_list):
     html_content = "<div style='height: 300px; overflow-y: scroll;'><ul>"
     for file in file_list:
         # print(f"file: {file}")
-        html_content += f"<li><a href='#' class='file-link' onclick='loadFile(\"{file}\")'>{file}</a></li>"
+        html_content += f"<li><button style='background-color:FFFFFF00;'  onMouseOver=\"this.style.backgroundColor='#8888AA99'\" onMouseOut=\"this.style.backgroundColor='#FFFFFF00'\"  onclick='loadFile(\"{file}\")'>{file}</button></li>"
     html_content += "</ul></div>"
     return html_content
 
@@ -66,11 +66,11 @@ def on_ui_tabs():
         with gr.Row(elem_id=f"unprompted_toprow"):
             with gr.Column(scale=1, min_width=200):
                 # Add HTML element for file list
-                templates = gr.HTML(value="", elem_id="file_list", css=".file_list_container { height: 300px; overflow-y: scroll; }")
+                templates = gr.HTML(value="", elem_id="file_list", css=".myButtons:hover {background-color: #4CAF50;color: white;}")
                 with gr.Row():  
-                    refresh_button = ToolButton(value=refresh_symbol, elem_id=f"refresh_button_unprompted")
-                    load_button = ToolButton(value=folder_symbol, elem_id=f"load_button_unprompted")
-                    save_button = ToolButton(value=save_style_symbol, elem_id=f"save_button_unprompted")
+                    refresh_button_unprompted = ToolButton(value=refresh_symbol, elem_id=f"refresh_button_unprompted")
+                    load_button_unprompted = ToolButton(value=folder_symbol_unprompted, elem_id=f"load_button_unprompted")
+                    save_button_unprompted = ToolButton(value=save_style_symbol_unprompted, elem_id=f"save_button_unprompted")
                 with gr.Row():
                     # Add save name text box
                     save_name = gr.Textbox(value="", label="Save Name", elem_id="save_name")
@@ -83,7 +83,7 @@ def on_ui_tabs():
                     extra_networks_ui_unprompted_edit_space = ui_extra_networks.create_ui(extra_networks, extra_networks_button, 'unprompted_edit_space')
                     extra_networks_ui_unprompted_gallery = gr.Textbox(visible=False)
         ui_extra_networks.setup_ui(extra_networks_ui_unprompted_edit_space, extra_networks_ui_unprompted_gallery)
-        refresh_button.click(
+        refresh_button_unprompted.click(
             fn=refresh_file_list,
             inputs=[
             ],
@@ -91,7 +91,7 @@ def on_ui_tabs():
             templates,
             ]
         )
-        load_button.click(
+        load_button_unprompted.click(
             fn=load_file,
             inputs=[
                 save_name,
@@ -100,7 +100,7 @@ def on_ui_tabs():
                 main_edit_space,
             ]
         )
-        save_button.click(
+        save_button_unprompted.click(
             fn=save_file,
             inputs=[
                 save_name,

--- a/scripts/unprompted_template_editer.py
+++ b/scripts/unprompted_template_editer.py
@@ -110,6 +110,6 @@ def on_ui_tabs():
             ]
         )
 
-    return (unprompted_editor_ui, "Unprompted Template Editer", "unprompted_editor_ui"),
+    return (unprompted_editor_ui, "Unprompted Template Editor", "unprompted_editor_ui"),
 
 script_callbacks.on_ui_tabs(on_ui_tabs)

--- a/shortcodes/stable_diffusion/img_save_name.py
+++ b/shortcodes/stable_diffusion/img_save_name.py
@@ -1,0 +1,14 @@
+class Shortcode():
+	def __init__(self,Unprompted):
+		self.Unprompted = Unprompted
+		self.description = "changes the filename of the image."
+	def run_atomic(self, pargs, kwargs, context):
+		from modules.shared import opts, cmd_opts
+
+		opts.samples_filename_pattern = self.Unprompted.parse_advanced(pargs[0],context)
+		# #remove the original images from the output
+
+		return("")
+
+	def ui(self,gr):
+		pass


### PR DESCRIPTION
This adds a tab that allows you to edit templates saved on a remote computer if using the UI over the web or through the --listen command.

it also lets you have access to the ctrl+arrows commands to edit the strength of terms and gives you access to your loras and TIs directly in a UI where you can update your templates.

I know an extra tab may be excessive for some so I'll understand if you don't want to merge but I really wanted this feature so i made it for myself and I love your tool so I decided to try to contribute. 
![Capture](https://user-images.githubusercontent.com/4039558/236370651-fe0541f9-7eda-40fc-b850-93c8d303cd35.PNG)
