### PR TITLE
Expose unprompted_seed and sd_seed/Fix model switch memory leak

### DIFF
--- a/lib_unprompted/shared.py
+++ b/lib_unprompted/shared.py
@@ -653,7 +653,7 @@ class Unprompted:
 			elif att == "sd_model" and self.shortcode_user_vars[att] != self.original_model and isinstance(self.shortcode_user_vars[att], str):
 				info = sd_models.get_closet_checkpoint_match(self.shortcode_user_vars["sd_model"])
 				if info:
-					new_model = sd_models.load_model(info, None)  #, None
+					new_model = sd_models.reload_model_weights(info=info)
 					self.update_stable_diffusion_architecture_vars(new_model)
 			elif att == "sd_vae":
 				from modules import sd_vae

--- a/scripts/unprompted.py
+++ b/scripts/unprompted.py
@@ -1085,6 +1085,8 @@ class Scripts(scripts.Script):
 		Unprompted.shortcode_user_vars["sd_model"] = opts.data["sd_model_checkpoint"]
 		Unprompted.shortcode_user_vars["sd_base"] = "none"
 		Unprompted.shortcode_user_vars["sd_res"] = 1024
+		Unprompted.shortcode_user_vars["unprompted_seed"] = unprompted_seed
+		Unprompted.shortcode_user_vars["sd_seed"] = p.seed
 		if sd_models.model_data.sd_model:
 			Unprompted.update_stable_diffusion_architecture_vars(sd_models.model_data.sd_model)
 


### PR DESCRIPTION
Exposing the seed used for unprompted and stable diffusion is useful for developing new shortcodes that use `random` calls, allowing synchronization of these shortcodes with the unprompted or stable diffusion seeds.

In addition, fixes a memory leak when repeatedly swapping checkpoints.